### PR TITLE
Corresponding to the spec change of crystal

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,0 +1,7 @@
+name: twitter-crystal
+version: 0.1.0
+
+authors:
+  - Erik Michaels-Ober <sferik@gmail.com>
+
+license: Apache

--- a/src/twitter/rest/client.cr
+++ b/src/twitter/rest/client.cr
@@ -53,7 +53,7 @@ module Twitter
       end
 
       private def to_query_string(hash : Hash)
-        CGI.build_form do |form_builder|
+        HTTP::Params.build do |form_builder|
           hash.each do |key, value|
             form_builder.add(key, value)
           end


### PR DESCRIPTION
- Replace Projectfile with shard.yml.
  - Crystal v0.8.0 adopted Shards as a dependencry manager.
- Renew "CGI.build_form" with "HTTP::Params.build".
  - Crystal dismantled CGI module.
  - Crystal move `build_form` as `build` to newly created `HTTP::Params`.
