### PR TITLE
ready for Crystal 0.24.1

### DIFF
--- a/spec/mock/client.cr
+++ b/spec/mock/client.cr
@@ -23,7 +23,7 @@ module Mock
       HTTP::Client::Response.new(400, %({"errors":[{"code":400,"message":"Invalid or expired token"}]}))
     end
 
-    def post_form(path : String, form = {} of String => String)
+    def post(path : String, form = {} of String => String)
       HTTP::Client::Response.new(400, %({"errors":[{"code":400,"message":"Invalid or expired token"}]}))
     end
   end

--- a/src/twitter/rest/client.cr
+++ b/src/twitter/rest/client.cr
@@ -31,7 +31,7 @@ module Twitter
       end
 
       def post(path : String, form = {} of String => String)
-        response = @http_client.post_form(path, form)
+        response = @http_client.post(path, form: form)
         handle_response(response)
       end
 


### PR DESCRIPTION
 In Crystal 0.24.0 `HTTP::Client#post_form` is now `HTTP::Client.post(form: ...)`