### PR TITLE
add #delete to Twitter::REST::Client

### DIFF
--- a/src/twitter/rest/client.cr
+++ b/src/twitter/rest/client.cr
@@ -35,6 +35,11 @@ module Twitter
         handle_response(response)
       end
 
+      def delete(path : String, params = {} of String => String)
+        response = @http_client.delete(path)
+        handle_response(response)
+      end
+
       private def handle_response(response : HTTP::Client::Response)
         case response.status_code
         when 200..299


### PR DESCRIPTION
The `DELETE` HTTP method is useful for working with hooks and subscriptions using the Account Activity API, as in https://github.com/bkerley/switch_streamer/blob/5f6dee31b196d8c9ebf12dc34996c24381969d01/src/switch_streamer/client.cr#L64